### PR TITLE
Export to SVG

### DIFF
--- a/Libo_PlantUML/PlantUML/PlantUML.xba
+++ b/Libo_PlantUML/PlantUML/PlantUML.xba
@@ -243,14 +243,14 @@ Sub PlantUMLAll
 			WriteTempFile( vSelection, tempFile &amp; &quot;.txt&quot;  )
 
 			Dim shellparam as String
-			shellparam =  &quot; -jar &quot;&quot;&quot; &amp; ConvertFromURL( tempFile ) &amp; &quot;.jar&quot;&quot; -charset UTF-8 &quot;&quot;&quot; &amp; ConvertFromURL( tempFile ) &amp; &quot;.txt&quot;&quot;&quot;
+			shellparam =  &quot; -jar &quot;&quot;&quot; &amp; ConvertFromURL( tempFile ) &amp; &quot;.jar&quot;&quot; -tsvg -charset UTF-8 &quot;&quot;&quot; &amp; ConvertFromURL( tempFile ) &amp; &quot;.txt&quot;&quot;&quot;
 
 			Shell( javacmd, 2, shellparam, TRUE )
 
 			RemovePreviousGraphics( vSelection )
 
 			Dim myUrl$
-			myUrl$ = ConvertToURL( tempFile &amp; &quot;.png&quot; )
+			myUrl$ = ConvertToURL( tempFile &amp; &quot;.svg&quot; )
 		    If FileExists(myUrl) Then
 
 				Dim oPar		&apos; Current paragraph

--- a/Libo_PlantUML/PlantUML/Utils.xba
+++ b/Libo_PlantUML/PlantUML/Utils.xba
@@ -8,61 +8,29 @@
 &apos; oCurs - Cursor where the image is added
 &apos; sURL - URL of the image to insert.
 &apos; sParStyle - set the paragraph style to this.
-&apos; This function is taken from Andrews macro book. Changed anchor to paragraph.
+&apos; Based on https://ask.libreoffice.org/t/programatically-insert-a-svg-file-into-writer-document-from-a-macro-with-a-correct-size/128358/6
 &apos;
 Sub EmbedGraphic(oDoc, oCurs, sURL$, sParStyle$)
-  Dim oShape
-  Dim oGraph     &apos;The graphic object is text content.
-  Dim oProvider  &apos;GraphicProvider service.
   Dim oText
-
-  oShape = oDoc.createInstance(&quot;com.sun.star.drawing.GraphicObjectShape&quot;)
-  oGraph = oDoc.createInstance(&quot;com.sun.star.text.GraphicObject&quot;)
-
-  oDoc.getDrawPage().add(oShape)
+  Dim oProvider  &apos;GraphicProvider service.
+  Dim oGraph     &apos;The graphic object is text content.
 
   oProvider = createUnoService(&quot;com.sun.star.graphic.GraphicProvider&quot;)
+  oGraph = oDoc.createInstance(&quot;com.sun.star.text.GraphicObject&quot;)
 
   Dim oProps(0) as new com.sun.star.beans.PropertyValue
   oProps(0).Name  = &quot;URL&quot;
   oProps(0).Value = sURL
 
-  REM Save the original size.
-  Dim oSize100thMM
-  Dim lHeight As Long
-  Dim lWidth As Long
-  oSize100thMM = RecommendGraphSize(oDoc, oCurs, oProvider.queryGraphicDescriptor(oProps))
-  If NOT IsNull(oSize100thMM) AND NOT IsEmpty(oSize100thMM) Then
-    lHeight = oSize100thMM.Height
-    lWidth = oSize100thMM.Width
-  End If
-
-
-  oShape.Graphic = oProvider.queryGraphic(oProps())
-
-  REM taking care of change in oShape in LibreOffice 6.1
-  If getSolarversion &lt; 60100 then
-	  oGraph.graphicurl = oShape.graphicurl
-  else
-	  oGraph.graphic = oShape.graphic
-  end if
-  
+  oGraph.graphic = oProvider.queryGraphic(oProps)
   oGraph.AnchorType = com.sun.star.text.TextContentAnchorType.AT_PARAGRAPH
   oGraph.TextWrap = com.sun.star.text.WrapTextMode.NONE 
   oGraph.HoriOrient = com.sun.star.text.HoriOrientation.CENTER
+  oGraph.Size = oGraph.Graphic.Size100thMM
 
   oText= oCurs.getText()
   oText.insertTextContent(oCurs, oGraph, false)
-  oDoc.getDrawPage().remove(oShape)
 
-  If lHeight &gt; 0 AND lWidth &gt; 0 Then
-    Dim oSize
-    oSize = oGraph.Size
-    oSize.Height = lHeight
-    oSize.Width = lWidth
-    oGraph.Size = oSize
-  End If
-  
   &apos; Set the paragraph style if it is in the document.
   Dim oStyles
   oStyles = oDoc.StyleFamilies.getByName(&quot;ParagraphStyles&quot;)


### PR DESCRIPTION
Fixes #26. The resulting SVG wasn't shown correctly when I tried to use it with LO25, but it seems correct on LO26, so it was probably fixed at some point.

LO25:

<img width="375" height="364" alt="image" src="https://github.com/user-attachments/assets/c9fa2ab9-6aa3-4c58-a7fe-dfcfcab00768" />

LO26:

<img width="696" height="626" alt="image" src="https://github.com/user-attachments/assets/c52e1bfb-37ad-48c3-b383-1f7e36c358eb" />

